### PR TITLE
Updating default consul image tag to 1.15.4

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "consul_image" {
   description = "Image to use when deploying consul, defaults to the hashicorp consul image"
-  default     = "consul:latest"
+  default     = "consul:1.15.4"
 }
 
 variable "consul_memory_reservation" {


### PR DESCRIPTION
Hashicorp got rid of their `latest` tag which we point to in several places.  `1.15.4` appears to be the latest version that we want to use as of writing this.  Once this is approved and merged I will publish a new major version to be referenced in each ECS cluster